### PR TITLE
Fix misalignment in depth<->RGB registration

### DIFF
--- a/Samples/StreamRecorder/StreamRecorderConverter/save_pclouds.py
+++ b/Samples/StreamRecorder/StreamRecorderConverter/save_pclouds.py
@@ -208,7 +208,7 @@ def load_extrinsics(extrinsics_path):
 def get_points_in_cam_space(img, lut):
     img = np.tile(img.flatten().reshape((-1, 1)), (1, 3))
     points = img * lut
-    remove_ids = np.where(np.sum(points, axis=1) < 1e-6)[0]
+    remove_ids = np.where(np.sqrt(np.sum(points**2, axis=1)) < 1e-6)[0]
     points = np.delete(points, remove_ids, axis=0)
     points /= 1000.
     return points
@@ -222,15 +222,18 @@ def cam2world(points, rig2cam, rig2world):
 
 
 def extract_timestamp(path):
-    return float(path.split('.')[0])
+    return int(path.split('.')[0])
 
 
 def load_rig2world_transforms(path):
     transforms = {}
-    data = np.loadtxt(str(path), delimiter=',')
-    for value in data:
-        timestamp = value[0]
-        transform = value[1:].reshape((4, 4))
+    with open(path, "r") as f:
+        lines = [l.strip() for l in f.readlines()]
+    for line in lines:
+        value = line.split(",")
+        timestamp = int(value[0])
+        transform_entries = [float(v) for v in value[1:]]
+        transform = np.array(transform_entries).reshape((4, 4))
         transforms[timestamp] = transform
     return transforms
 

--- a/Samples/StreamRecorder/StreamRecorderConverter/utils.py
+++ b/Samples/StreamRecorder/StreamRecorderConverter/utils.py
@@ -122,14 +122,14 @@ def project_on_pv(points, pv_img, pv2world_transform, focal_length, principal_po
     world2pv_transform = np.linalg.inv(pv2world_transform)
     points_pv = (world2pv_transform @ homog_points.T).T[:, :3]
 
-    intrinsic_matrix = np.array([[focal_length[0], 0, principal_point[0]], [
+    intrinsic_matrix = np.array([[focal_length[0], 0, width-principal_point[0]], [
         0, focal_length[1], principal_point[1]], [0, 0, 1]])
     rvec = np.zeros(3)
     tvec = np.zeros(3)
     xy, _ = cv2.projectPoints(points_pv, rvec, tvec, intrinsic_matrix, None)
     xy = np.squeeze(xy)
     xy[:, 0] = width - xy[:, 0]
-    xy = np.around(xy).astype(int)
+    xy = np.floor(xy).astype(int)
 
     rgb = np.zeros_like(points)
     width_check = np.logical_and(0 <= xy[:, 0], xy[:, 0] < width)


### PR DESCRIPTION
- Fixes misalignment in depth<->RGB registration produced by flipped sign in principal_point_x.
- Fixes parsing of the timestamps, which were casted to floats instead of ints, introducing modifications of the values.
- Uses floor instead of round for projection of points from 3D to 2D image space, assuming that the convention from COLMAP is adopted, where the 2D pixel coordinates are [0.5,...,H-0.5]x[0.5,...,W-0.5].
- Fixes bug in masking of invalid 3D points